### PR TITLE
feat: Multiple procedures 
  support (Issue #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Previously, all procedures were merged into a single "Blocks" sheet, which made it difficult to distinguish between experiments run on different regions of interest (ROIs)
 - Shared data (Experiment, Racks, ROIs, Samples) remains in common sheets
 
-### v1.x (Previous behaviour)
+### v1.x (Previous)
 - All procedure blocks were combined into a single "Blocks" sheet
 - This worked well for single-procedure experiments but did not clearly separate multiple procedures
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # MACSima Parser
 
 **MACSima Parser** helps you turn experiment data from a MACSima imaging run (in `.json` format) into a clear Excel file you can open in Excel, Google Sheets, or similar tools.
+
+## Version History
+
+### v2.0.0 (Current)
+- **Multiple procedures support**: Each procedure now gets its own Excel sheet, named after the procedure
+- Previously, all procedures were merged into a single "Blocks" sheet, which made it difficult to distinguish between experiments run on different regions of interest (ROIs)
+- Shared data (Experiment, Racks, ROIs, Samples) remains in common sheets
+
+### v1.x (Previous behaviour)
+- All procedure blocks were combined into a single "Blocks" sheet
+- This worked well for single-procedure experiments but did not clearly separate multiple procedures
+
+---
+
 You do not need to know Python to use this tool!
 Try the UI here: [https://macsima-parser.onrender.com/](https://macsima-parser.onrender.com/)
 

--- a/app.py
+++ b/app.py
@@ -6,7 +6,15 @@ from werkzeug.utils import secure_filename
 import logging
 
 # Import your existing parser
-from src.macsima_parser import load_json, build_bucket_lookup, process_experiment, process_rois, process_sample, process_block, add_numbers_to_run_cycles, propagate_magnification, add_blank_lines_between_run_cycles, get_rack_name
+from src.macsima_parser import (
+    load_json,
+    build_bucket_lookup,
+    process_experiment,
+    process_rois,
+    process_sample,
+    process_all_procedures,
+    get_rack_name,
+)
 import pandas as pd
 
 app = Flask(__name__)
@@ -69,36 +77,32 @@ def get_user_friendly_error_message(exception, filename):
 def process_json_to_excel(json_file_path):
     """Process JSON file and return Excel file path"""
     logger.info(f"Processing JSON file: {json_file_path}")
-    
+
     # Load and process the JSON data
     data = load_json(json_file_path)
     bucket_lookup = build_bucket_lookup(data)
 
-    # Gather rows
+    # Gather rows for shared sheets
     exp_rows = [process_experiment(e) for e in data["experiments"]]
     rack_rows = [{"RackName": get_rack_name(r)} for r in data["racks"]]
     roi_rows = [process_rois(r) for r in data["rois"]]
     sample_rows = [process_sample(s) for s in data["samples"]]
 
-    block_rows = []
-    for proc in data["procedures"]:
-        blocks = add_numbers_to_run_cycles(proc["blocks"])
-        blocks = propagate_magnification(blocks)
-        for b in blocks:
-            block_rows.extend(process_block(b, bucket_lookup))
-
-    # Add blank lines between different run cycles
-    block_rows = add_blank_lines_between_run_cycles(block_rows)
+    # Process all procedures into a dictionary keyed by procedure name
+    procedures_dict = process_all_procedures(data, bucket_lookup)
 
     # Create Excel file
     excel_path = Path(json_file_path).with_suffix(".xlsx")
-    
+
     with pd.ExcelWriter(excel_path, engine="xlsxwriter") as xls:
         pd.DataFrame(exp_rows).to_excel(xls, sheet_name="Experiment", index=False)
         pd.DataFrame(rack_rows).to_excel(xls, sheet_name="Racks", index=False)
         pd.DataFrame(roi_rows).to_excel(xls, sheet_name="ROIs", index=False)
         pd.DataFrame(sample_rows).to_excel(xls, sheet_name="Samples", index=False)
-        pd.DataFrame(block_rows).to_excel(xls, sheet_name="Blocks", index=False)
+
+        # Write each procedure to its own sheet
+        for proc_name, block_rows in procedures_dict.items():
+            pd.DataFrame(block_rows).to_excel(xls, sheet_name=proc_name, index=False)
 
     logger.info(f"Excel report created successfully: {excel_path}")
     return str(excel_path)

--- a/src/macsima_parser.py
+++ b/src/macsima_parser.py
@@ -122,8 +122,44 @@ def get_experiment_name(experiment: dict[str, Any]) -> str:
 
 def get_procedure_name(procedure: dict[str, Any]) -> str:
     """Returns the procedure name."""
-    # NOTE: assume only one procedure in the file
     return procedure.get("comment", "Unknown procedure")
+
+
+def sanitise_sheet_name(name: str, max_length: int = 31) -> str:
+    """
+    Sanitise a string for use as an Excel sheet name.
+
+    Excel sheet names have these restrictions:
+    - Maximum 31 characters
+    - Cannot contain: \\ / ? * [ ] :
+    - Cannot be blank
+
+    Parameters
+    ----------
+    name : str
+        The raw name to sanitise.
+    max_length : int
+        Maximum length for the sheet name (default 31).
+
+    Returns
+    -------
+    str
+        A valid Excel sheet name.
+    """
+    if not name or not name.strip():
+        return "Procedure"
+
+    # Remove invalid characters
+    invalid_chars = ['\\', '/', '?', '*', '[', ']', ':']
+    sanitised = name
+    for char in invalid_chars:
+        sanitised = sanitised.replace(char, '_')
+
+    # Trim to max length
+    if len(sanitised) > max_length:
+        sanitised = sanitised[:max_length]
+
+    return sanitised.strip() or "Procedure"
 
 def get_rack_name(rack: list[dict[str, Any]]) -> str:
     """Returns the rack name."""
@@ -698,6 +734,61 @@ def process_block(block: dict[str, Any],
     return rows
 
 
+def process_all_procedures(data: dict[str, Any], bucket_lookup: dict[str, Any]) -> Dict[str, list[dict]]:
+    """
+    Process all procedures and return a dictionary keyed by procedure name.
+
+    Each procedure's blocks are processed and stored under a unique key.
+    If multiple procedures have the same name, a numeric suffix is added.
+
+    Parameters
+    ----------
+    data : dict
+        The loaded JSON data containing procedures.
+    bucket_lookup : dict
+        The bucket-to-reagent lookup table.
+
+    Returns
+    -------
+    Dict[str, list[dict]]
+        A dictionary where keys are sanitised procedure names and values
+        are lists of processed block rows.
+    """
+    procedures_dict: Dict[str, list[dict]] = {}
+    name_counts: Dict[str, int] = {}
+
+    for proc in data.get("procedures", []):
+        # Get the procedure name
+        raw_name = get_procedure_name(proc)
+        base_name = sanitise_sheet_name(raw_name)
+
+        # Handle duplicate names by adding a numeric suffix
+        if base_name in name_counts:
+            name_counts[base_name] += 1
+            # Ensure the suffix fits within Excel's 31 char limit
+            suffix = f" ({name_counts[base_name]})"
+            max_base_len = 31 - len(suffix)
+            unique_name = sanitise_sheet_name(base_name, max_base_len) + suffix
+        else:
+            name_counts[base_name] = 1
+            unique_name = base_name
+
+        # Process the procedure's blocks
+        blocks = add_numbers_to_run_cycles(proc.get("blocks", []))
+        blocks = propagate_magnification(blocks)
+
+        block_rows: list[dict] = []
+        for b in blocks:
+            block_rows.extend(process_block(b, bucket_lookup))
+
+        # Add blank lines between different run cycles
+        block_rows = add_blank_lines_between_run_cycles(block_rows)
+
+        procedures_dict[unique_name] = block_rows
+
+    return procedures_dict
+
+
 if __name__ == "__main__":
     json_path = get_input_path()
     logger.info(f"Loading JSON: {json_path}")
@@ -710,17 +801,8 @@ if __name__ == "__main__":
     roi_rows    = [process_rois(r)       for r in data["rois"]]
     sample_rows = [process_sample(s)     for s in data["samples"]]
 
-    block_rows: list[dict] = []
-    for proc in data["procedures"]:
-        # add run-cycle numbers once
-        blocks = add_numbers_to_run_cycles(proc["blocks"])
-        # propagate magnification through the block list
-        blocks = propagate_magnification(blocks)
-        for b in blocks:
-            block_rows.extend(process_block(b, bucket_lookup))
-
-    # Add blank lines between different run cycles
-    block_rows = add_blank_lines_between_run_cycles(block_rows)
+    # Process all procedures into a dictionary keyed by procedure name
+    procedures_dict = process_all_procedures(data, bucket_lookup)
 
     # ---------- to Excel ---------------------------------------
     out_xlsx = json_path.with_suffix(".xlsx")
@@ -733,8 +815,9 @@ if __name__ == "__main__":
         pd.DataFrame(roi_rows   ).to_excel(xls, sheet_name="ROIs",       index=False)
         pd.DataFrame(sample_rows).to_excel(xls, sheet_name="Samples",    index=False)
 
-        # big table of all blocks & channels
-        pd.DataFrame(block_rows ).to_excel(xls, sheet_name="Blocks",     index=False)
+        # Write each procedure to its own sheet
+        for proc_name, block_rows in procedures_dict.items():
+            pd.DataFrame(block_rows).to_excel(xls, sheet_name=proc_name, index=False)
 
     logger.info("✅ Excel report created successfully.")
     logger.info(f"📊 Excel report saved to: {out_xlsx}")

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -1523,7 +1523,8 @@ def test_sanitise_sheet_name_custom_max_length():
     name = "This is a test name"
     result = mp.sanitise_sheet_name(name, max_length=10)
     assert len(result) <= 10
-    assert result == "This is a "
+    # Trailing space is stripped by the function
+    assert result == "This is a"
 
 
 def test_process_all_procedures_single():

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -1485,3 +1485,193 @@ def test_flask_error_message_function():
     except ImportError:
         # Skip this test if Flask dependencies are not available
         pytest.skip("Flask dependencies not available for testing")
+
+
+# --------------------------------------------------
+# Multiple procedures tests (Issue #16)
+# --------------------------------------------------
+
+def test_sanitise_sheet_name_basic():
+    """Test that sanitise_sheet_name handles basic cases correctly."""
+    # Normal name
+    assert mp.sanitise_sheet_name("Standard procedure") == "Standard procedure"
+
+    # Name with invalid characters
+    assert mp.sanitise_sheet_name("Proc/with\\invalid:chars?") == "Proc_with_invalid_chars_"
+
+    # Name with square brackets and asterisk
+    assert mp.sanitise_sheet_name("Proc[1]*test") == "Proc_1__test"
+
+
+def test_sanitise_sheet_name_length():
+    """Test that sanitise_sheet_name truncates long names to 31 characters."""
+    long_name = "This is a very long procedure name that exceeds the Excel limit"
+    result = mp.sanitise_sheet_name(long_name)
+    assert len(result) <= 31
+    assert result == "This is a very long procedure n"
+
+
+def test_sanitise_sheet_name_empty():
+    """Test that sanitise_sheet_name handles empty and blank names."""
+    assert mp.sanitise_sheet_name("") == "Procedure"
+    assert mp.sanitise_sheet_name("   ") == "Procedure"
+    assert mp.sanitise_sheet_name(None) == "Procedure"
+
+
+def test_sanitise_sheet_name_custom_max_length():
+    """Test that sanitise_sheet_name respects custom max_length."""
+    name = "This is a test name"
+    result = mp.sanitise_sheet_name(name, max_length=10)
+    assert len(result) <= 10
+    assert result == "This is a "
+
+
+def test_process_all_procedures_single():
+    """Test process_all_procedures with a single procedure."""
+    bucket_lookup = mp.build_bucket_lookup(data)
+    result = mp.process_all_procedures(data, bucket_lookup)
+
+    # Should return a dictionary with one entry
+    assert isinstance(result, dict)
+    assert len(result) == 1
+
+    # Key should be the procedure name
+    assert "Standard procedure" in result
+
+    # Value should be a list of block rows
+    block_rows = result["Standard procedure"]
+    assert isinstance(block_rows, list)
+    assert len(block_rows) > 0
+
+
+def test_process_all_procedures_multiple():
+    """Test process_all_procedures with multiple procedures."""
+    # Create data with multiple procedures
+    multi_proc_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": [
+            {
+                "comment": "Procedure A",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_2x"},
+                ]
+            },
+            {
+                "comment": "Procedure B",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_20x"},
+                ]
+            },
+            {
+                "comment": "Procedure C",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_40x"},
+                ]
+            }
+        ]
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(multi_proc_data)
+    result = mp.process_all_procedures(multi_proc_data, bucket_lookup)
+
+    # Should return a dictionary with three entries
+    assert isinstance(result, dict)
+    assert len(result) == 3
+
+    # Keys should be the procedure names
+    assert "Procedure A" in result
+    assert "Procedure B" in result
+    assert "Procedure C" in result
+
+
+def test_process_all_procedures_duplicate_names():
+    """Test process_all_procedures handles duplicate procedure names."""
+    # Create data with duplicate procedure names
+    dup_proc_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": [
+            {
+                "comment": "Same Name",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_2x"},
+                ]
+            },
+            {
+                "comment": "Same Name",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_20x"},
+                ]
+            },
+            {
+                "comment": "Same Name",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_40x"},
+                ]
+            }
+        ]
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(dup_proc_data)
+    result = mp.process_all_procedures(dup_proc_data, bucket_lookup)
+
+    # Should return a dictionary with three unique entries
+    assert isinstance(result, dict)
+    assert len(result) == 3
+
+    # Keys should be unique with numeric suffixes
+    assert "Same Name" in result
+    assert "Same Name (2)" in result
+    assert "Same Name (3)" in result
+
+
+def test_process_all_procedures_empty():
+    """Test process_all_procedures with no procedures."""
+    empty_proc_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": []
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(empty_proc_data)
+    result = mp.process_all_procedures(empty_proc_data, bucket_lookup)
+
+    # Should return an empty dictionary
+    assert isinstance(result, dict)
+    assert len(result) == 0
+
+
+def test_process_all_procedures_missing_comment():
+    """Test process_all_procedures handles procedures without comments."""
+    no_comment_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": [
+            {
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_2x"},
+                ]
+            }
+        ]
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(no_comment_data)
+    result = mp.process_all_procedures(no_comment_data, bucket_lookup)
+
+    # Should return a dictionary with one entry using the default name
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    assert "Unknown procedure" in result


### PR DESCRIPTION
## Summary
  - Each procedure now gets its own Excel sheet, 
  named after the procedure
  - Previously, all procedures were merged into a 
  single Blocks sheet
  - Shared data (Experiment, Racks, ROIs, Samples)
   remains in common sheets
  - Added sanitise_sheet_name() to handle Excel 
  31-char limit and invalid characters
  - Added process_all_procedures() function to 
  group blocks by procedure

  ## Test plan
  - [x] All 64 tests pass
  - [ ] Upload a JSON file with multiple 
  procedures and verify each gets its own sheet

  Closes #16