### PR TITLE
chore: Code cleanup and CI
   workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest flake8
+
+      - name: Lint with flake8
+        run: |
+          flake8 --ignore=E501,E402,E731,W503,E266,E252,F824 src/macsima_parser.py app.py
+
+      - name: Run tests
+        run: |
+          pytest src/test_macsima_parser.py -v

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Previously, all procedures were merged into a single "Blocks" sheet, which made it difficult to distinguish between experiments run on different regions of interest (ROIs)
 - Shared data (Experiment, Racks, ROIs, Samples) remains in common sheets
 
-### v1.x (Previous behaviour)
+### v1.x (Previous)
 - All procedure blocks were combined into a single "Blocks" sheet
 - This worked well for single-procedure experiments but did not clearly separate multiple procedures
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # MACSima Parser
 
 **MACSima Parser** helps you turn experiment data from a MACSima imaging run (in `.json` format) into a clear Excel file you can open in Excel, Google Sheets, or similar tools.
+
+## Version History
+
+### v2.0.0 (Current)
+- **Multiple procedures support**: Each procedure now gets its own Excel sheet, named after the procedure
+- Previously, all procedures were merged into a single "Blocks" sheet, which made it difficult to distinguish between experiments run on different regions of interest (ROIs)
+- Shared data (Experiment, Racks, ROIs, Samples) remains in common sheets
+
+### v1.x (Previous behaviour)
+- All procedure blocks were combined into a single "Blocks" sheet
+- This worked well for single-procedure experiments but did not clearly separate multiple procedures
+
+---
+
 You do not need to know Python to use this tool!
 Try the UI here: [https://macsima-parser.onrender.com/](https://macsima-parser.onrender.com/)
 

--- a/app.py
+++ b/app.py
@@ -1,8 +1,7 @@
-from flask import Flask, request, send_file, render_template, flash, redirect, url_for, jsonify
+from flask import Flask, request, send_file, render_template, jsonify
 import os
 import tempfile
 from pathlib import Path
-from werkzeug.utils import secure_filename
 import logging
 
 # Import your existing parser
@@ -34,11 +33,11 @@ def get_user_friendly_error_message(exception, filename):
     """Convert technical exceptions into user-friendly error messages"""
     error_str = str(exception).lower()
     exception_type = type(exception).__name__
-    
+
     # Check exception type first for more accurate detection
     if exception_type == 'JSONDecodeError' or 'json' in error_str and ('decode' in error_str or 'parse' in error_str or 'expecting' in error_str):
         return f"The file '{filename}' is not valid JSON. Please check that the file contains properly formatted JSON data with correct syntax (matching braces, commas, quotes)."
-    
+
     elif exception_type == 'KeyError' or 'key' in error_str and ('error' in error_str or 'missing' in error_str):
         # Try to determine which field is missing
         missing_field = str(exception).strip("'\"")
@@ -54,22 +53,22 @@ def get_user_friendly_error_message(exception, filename):
             return f"The JSON file '{filename}' is missing the required 'samples' field. Your JSON must contain a 'samples' array with sample information."
         else:
             return f"The JSON file '{filename}' is missing required data fields. Your JSON must contain these top-level fields: 'experiments', 'procedures', 'racks', 'rois', and 'samples'."
-    
+
     elif 'memory' in error_str or 'size' in error_str:
         return f"The file '{filename}' is too large or complex to process. Please try with a smaller file or contact support."
-    
+
     elif 'permission' in error_str or 'access' in error_str:
         return "Unable to process the file due to system permissions. Please try again or contact support."
-    
+
     elif 'timeout' in error_str:
         return f"Processing '{filename}' took too long and timed out. Please try with a smaller file."
-    
+
     elif 'isoformat' in error_str or 'date' in error_str:
         return f"The file '{filename}' contains invalid date/time formats. Please ensure all datetime fields use ISO format (e.g., '2025-01-01T10:00:00Z')."
-    
+
     elif 'attribute' in error_str and 'get' in error_str:
         return f"The file '{filename}' has incorrect data types or structure. Please verify that objects contain the expected fields and data types."
-    
+
     else:
         # For unknown errors, provide a generic but helpful message
         return f"An unexpected error occurred while processing '{filename}'. The file may be corrupted or in an unsupported format. Please check the JSON structure and data types."
@@ -118,15 +117,15 @@ def upload_file():
             'error': True,
             'message': 'No file selected'
         }), 400
-    
+
     file = request.files['file']
-    
+
     if file.filename == '':
         return jsonify({
             'error': True,
             'message': 'No file selected'
         }), 400
-    
+
     if file and allowed_file(file.filename):
         temp_json_path = None
         excel_path = None
@@ -135,10 +134,10 @@ def upload_file():
             with tempfile.NamedTemporaryFile(delete=False, suffix='.json') as temp_json:
                 temp_json_path = temp_json.name
                 file.save(temp_json_path)
-                
+
             # Process the JSON file
             excel_path = process_json_to_excel(temp_json_path)
-            
+
             # Send the Excel file to user
             response = send_file(
                 excel_path,
@@ -146,7 +145,7 @@ def upload_file():
                 download_name=f"{Path(file.filename).stem}_report.xlsx",
                 mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
             )
-            
+
             # Schedule cleanup after response is sent
             @response.call_on_close
             def cleanup():
@@ -157,9 +156,9 @@ def upload_file():
                         os.unlink(excel_path)
                 except Exception as e:
                     logger.warning(f"Failed to cleanup temporary files: {e}")
-            
+
             return response
-                
+
         except Exception as e:
             # Cleanup on error
             try:
@@ -167,13 +166,13 @@ def upload_file():
                     os.unlink(temp_json_path)
                 if excel_path and os.path.exists(excel_path):
                     os.unlink(excel_path)
-            except:
+            except Exception:
                 pass
-            
+
             # Provide user-friendly error messages
             error_message = get_user_friendly_error_message(e, file.filename)
             logger.error(f"Processing error for {file.filename}: {str(e)}")
-            
+
             # Always return JSON error response for upload endpoint
             return jsonify({
                 'error': True,

--- a/app.py
+++ b/app.py
@@ -26,8 +26,10 @@ logger = logging.getLogger(__name__)
 
 ALLOWED_EXTENSIONS = {'json'}
 
+
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+
 
 def get_user_friendly_error_message(exception, filename):
     """Convert technical exceptions into user-friendly error messages"""
@@ -73,6 +75,7 @@ def get_user_friendly_error_message(exception, filename):
         # For unknown errors, provide a generic but helpful message
         return f"An unexpected error occurred while processing '{filename}'. The file may be corrupted or in an unsupported format. Please check the JSON structure and data types."
 
+
 def process_json_to_excel(json_file_path):
     """Process JSON file and return Excel file path"""
     logger.info(f"Processing JSON file: {json_file_path}")
@@ -106,9 +109,11 @@ def process_json_to_excel(json_file_path):
     logger.info(f"Excel report created successfully: {excel_path}")
     return str(excel_path)
 
+
 @app.route('/')
 def index():
     return render_template('index.html')
+
 
 @app.route('/upload', methods=['POST'])
 def upload_file():
@@ -184,6 +189,7 @@ def upload_file():
             'error': True,
             'message': 'Invalid file type. Please upload a JSON file.'
         }), 400
+
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -6,7 +6,15 @@ from werkzeug.utils import secure_filename
 import logging
 
 # Import your existing parser
-from src.macsima_parser import load_json, build_bucket_lookup, process_experiment, process_rois, process_sample, process_block, add_numbers_to_run_cycles, propagate_magnification, add_blank_lines_between_run_cycles, get_rack_name
+from src.macsima_parser import (
+    load_json,
+    build_bucket_lookup,
+    process_experiment,
+    process_rois,
+    process_sample,
+    process_all_procedures,
+    get_rack_name,
+)
 import pandas as pd
 
 app = Flask(__name__)
@@ -69,36 +77,32 @@ def get_user_friendly_error_message(exception, filename):
 def process_json_to_excel(json_file_path):
     """Process JSON file and return Excel file path"""
     logger.info(f"Processing JSON file: {json_file_path}")
-    
+
     # Load and process the JSON data
     data = load_json(json_file_path)
     bucket_lookup = build_bucket_lookup(data)
 
-    # Gather rows
+    # Gather rows for shared sheets
     exp_rows = [process_experiment(e) for e in data["experiments"]]
     rack_rows = [{"RackName": get_rack_name(r)} for r in data["racks"]]
     roi_rows = [process_rois(r) for r in data["rois"]]
     sample_rows = [process_sample(s) for s in data["samples"]]
 
-    block_rows = []
-    for proc in data["procedures"]:
-        blocks = add_numbers_to_run_cycles(proc["blocks"])
-        blocks = propagate_magnification(blocks)
-        for b in blocks:
-            block_rows.extend(process_block(b, bucket_lookup))
-
-    # Add blank lines between different run cycles
-    block_rows = add_blank_lines_between_run_cycles(block_rows)
+    # Process all procedures into a dictionary keyed by procedure name
+    procedures_dict = process_all_procedures(data, bucket_lookup)
 
     # Create Excel file
     excel_path = Path(json_file_path).with_suffix(".xlsx")
-    
+
     with pd.ExcelWriter(excel_path, engine="xlsxwriter") as xls:
         pd.DataFrame(exp_rows).to_excel(xls, sheet_name="Experiment", index=False)
         pd.DataFrame(rack_rows).to_excel(xls, sheet_name="Racks", index=False)
         pd.DataFrame(roi_rows).to_excel(xls, sheet_name="ROIs", index=False)
         pd.DataFrame(sample_rows).to_excel(xls, sheet_name="Samples", index=False)
-        pd.DataFrame(block_rows).to_excel(xls, sheet_name="Blocks", index=False)
+
+        # Write each procedure to its own sheet
+        for proc_name, block_rows in procedures_dict.items():
+            pd.DataFrame(block_rows).to_excel(xls, sheet_name=proc_name, index=False)
 
     logger.info(f"Excel report created successfully: {excel_path}")
     return str(excel_path)

--- a/src/macsima_parser.py
+++ b/src/macsima_parser.py
@@ -184,7 +184,10 @@ def get_start_time(experiment: dict) -> str:
 
 def get_end_time(experiment: dict[str]) -> str:
     """Returns the experiment end time."""
-    raw: str = experiment.get("executionEndDateTime", "Unknown end time")
+    raw: str | None = experiment.get("executionEndDateTime")
+
+    if not raw:
+        return "N/A (not completed)"
 
     # Parse it so you know it’s valid
     dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))

--- a/src/macsima_parser.py
+++ b/src/macsima_parser.py
@@ -122,8 +122,44 @@ def get_experiment_name(experiment: dict[str, Any]) -> str:
 
 def get_procedure_name(procedure: dict[str, Any]) -> str:
     """Returns the procedure name."""
-    # NOTE: assume only one procedure in the file
     return procedure.get("comment", "Unknown procedure")
+
+
+def sanitise_sheet_name(name: str, max_length: int = 31) -> str:
+    """
+    Sanitise a string for use as an Excel sheet name.
+
+    Excel sheet names have these restrictions:
+    - Maximum 31 characters
+    - Cannot contain: \\ / ? * [ ] :
+    - Cannot be blank
+
+    Parameters
+    ----------
+    name : str
+        The raw name to sanitise.
+    max_length : int
+        Maximum length for the sheet name (default 31).
+
+    Returns
+    -------
+    str
+        A valid Excel sheet name.
+    """
+    if not name or not name.strip():
+        return "Procedure"
+
+    # Remove invalid characters
+    invalid_chars = ['\\', '/', '?', '*', '[', ']', ':']
+    sanitised = name
+    for char in invalid_chars:
+        sanitised = sanitised.replace(char, '_')
+
+    # Trim to max length
+    if len(sanitised) > max_length:
+        sanitised = sanitised[:max_length]
+
+    return sanitised.strip() or "Procedure"
 
 def get_rack_name(rack: list[dict[str, Any]]) -> str:
     """Returns the rack name."""
@@ -698,6 +734,61 @@ def process_block(block: dict[str, Any],
     return rows
 
 
+def process_all_procedures(data: dict[str, Any], bucket_lookup: dict[str, Any]) -> Dict[str, list[dict]]:
+    """
+    Process all procedures and return a dictionary keyed by procedure name.
+
+    Each procedure's blocks are processed and stored under a unique key.
+    If multiple procedures have the same name, a numeric suffix is added.
+
+    Parameters
+    ----------
+    data : dict
+        The loaded JSON data containing procedures.
+    bucket_lookup : dict
+        The bucket-to-reagent lookup table.
+
+    Returns
+    -------
+    Dict[str, list[dict]]
+        A dictionary where keys are sanitised procedure names and values
+        are lists of processed block rows.
+    """
+    procedures_dict: Dict[str, list[dict]] = {}
+    name_counts: Dict[str, int] = {}
+
+    for proc in data.get("procedures", []):
+        # Get the procedure name
+        raw_name = get_procedure_name(proc)
+        base_name = sanitise_sheet_name(raw_name)
+
+        # Handle duplicate names by adding a numeric suffix
+        if base_name in name_counts:
+            name_counts[base_name] += 1
+            # Ensure the suffix fits within Excel's 31 char limit
+            suffix = f" ({name_counts[base_name]})"
+            max_base_len = 31 - len(suffix)
+            unique_name = sanitise_sheet_name(base_name, max_base_len) + suffix
+        else:
+            name_counts[base_name] = 1
+            unique_name = base_name
+
+        # Process the procedure's blocks
+        blocks = add_numbers_to_run_cycles(proc.get("blocks", []))
+        blocks = propagate_magnification(blocks)
+
+        block_rows: list[dict] = []
+        for b in blocks:
+            block_rows.extend(process_block(b, bucket_lookup))
+
+        # Add blank lines between different run cycles
+        block_rows = add_blank_lines_between_run_cycles(block_rows)
+
+        procedures_dict[unique_name] = block_rows
+
+    return procedures_dict
+
+
 if __name__ == "__main__":
     json_path = get_input_path()
     logger.info(f"Loading JSON: {json_path}")
@@ -710,17 +801,8 @@ if __name__ == "__main__":
     roi_rows    = [process_rois(r)       for r in data["rois"]]
     sample_rows = [process_sample(s)     for s in data["samples"]]
 
-    block_rows: list[dict] = []
-    for proc in data["procedures"]:
-        # add run-cycle numbers once
-        blocks = add_numbers_to_run_cycles(proc["blocks"])
-        # propagate magnification through the block list
-        blocks = propagate_magnification(blocks)
-        for b in blocks:
-            block_rows.extend(process_block(b, bucket_lookup))
-
-    # Add blank lines between different run cycles
-    block_rows = add_blank_lines_between_run_cycles(block_rows)
+    # Process all procedures into a dictionary keyed by procedure name
+    procedures_dict = process_all_procedures(data, bucket_lookup)
 
     # ---------- to Excel ---------------------------------------
     out_xlsx = json_path.with_suffix(".xlsx")
@@ -733,8 +815,9 @@ if __name__ == "__main__":
         pd.DataFrame(roi_rows   ).to_excel(xls, sheet_name="ROIs",       index=False)
         pd.DataFrame(sample_rows).to_excel(xls, sheet_name="Samples",    index=False)
 
-        # big table of all blocks & channels
-        pd.DataFrame(block_rows ).to_excel(xls, sheet_name="Blocks",     index=False)
+        # Write each procedure to its own sheet
+        for proc_name, block_rows in procedures_dict.items():
+            pd.DataFrame(block_rows).to_excel(xls, sheet_name=proc_name, index=False)
 
     logger.info("✅ Excel report created successfully.")
     logger.info(f"📊 Excel report saved to: {out_xlsx}")

--- a/src/macsima_parser.py
+++ b/src/macsima_parser.py
@@ -56,10 +56,10 @@ def add_blank_lines_between_run_cycles(block_rows: list[dict]) -> list[dict]:
         current_run_cycle = row.get(format_column_header("RunCycleNumber"), "")
 
         # If this is a new run cycle (and not the first row), add a blank line
-        if (prev_run_cycle is not None and
-            current_run_cycle != "" and
-            current_run_cycle != prev_run_cycle and
-            prev_run_cycle != ""):
+        if (prev_run_cycle is not None
+            and current_run_cycle != ""
+            and current_run_cycle != prev_run_cycle
+                and prev_run_cycle != ""):
 
             # Create a blank row with the same keys but empty values
             blank_row = {key: "" for key in row.keys()}
@@ -88,6 +88,7 @@ def get_input_path() -> Path:
     if not path.exists():
         raise FileNotFoundError(f"No such file: {path}")
     return path
+
 
 def load_json(json_file: JsonFile) -> Any:
     """
@@ -163,9 +164,11 @@ def sanitise_sheet_name(name: str, max_length: int = 31) -> str:
 
     return sanitised.strip() or "Procedure"
 
+
 def get_rack_name(rack: dict[str, Any]) -> str:
     """Returns the rack name."""
     return rack.get("name", "Unknown rack")
+
 
 def get_start_time(experiment: dict) -> str:
     """Return the experiment's start time as an RFC 3339 string with 'Z'."""
@@ -178,6 +181,7 @@ def get_start_time(experiment: dict) -> str:
     # Force UTC and format with a literal 'Z'
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
+
 def get_end_time(experiment: dict[str]) -> str:
     """Returns the experiment end time."""
     raw: str = experiment.get("executionEndDateTime", "Unknown end time")
@@ -188,12 +192,14 @@ def get_end_time(experiment: dict[str]) -> str:
     # Force UTC and format with a literal 'Z'
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-def convert_seconds_to_hms(seconds)-> Tuple[int, int, int]:
+
+def convert_seconds_to_hms(seconds) -> Tuple[int, int, int]:
     """Convert total seconds to (hours, minutes, seconds)."""
     hours = seconds // 3600
     minutes = (seconds % 3600) // 60
     sec_left = seconds % 60
     return hours, minutes, sec_left
+
 
 def get_running_time(experiment: dict[str, Any]) -> str:
     """
@@ -267,9 +273,11 @@ def get_used_disk_space(experiment: dict) -> str:
 # ROI helper functions
 # --------------------------------------------------
 
+
 def get_roi_name(roi: dict[str, Any]) -> str:
     """Returns the ROI name."""
     return roi.get("name", "Unknown ROI")
+
 
 def get_roi_shape_type(roi: dict[str, Any]) -> str:
     """return the ROI shape type."""
@@ -278,6 +286,7 @@ def get_roi_shape_type(roi: dict[str, Any]) -> str:
     # remove prefix "ShapeType_"
     shape_type = shape_type.replace("ShapeType_", "")
     return shape_type
+
 
 def get_roi_shape_height(roi):
     """Returns the ROI shape height."""
@@ -321,6 +330,7 @@ def get_roi_shape_height(roi):
         logger.warning(f"Error decoding JSON or accessing height: {e}")
     return str(height)
 
+
 def get_roi_shape_width(roi):
     """Returns the ROI shape width."""
     try:
@@ -363,6 +373,7 @@ def get_roi_shape_width(roi):
         logger.warning(f"Error decoding JSON or accessing width: {e}")
     return str(width)
 
+
 def get_autofocus_method(roi: dict[str, Any]) -> str:
     """Returns the autofocus method."""
     autofocus_method = roi.get("autoFocus", "Unknown autofocus method").get("method", "Unknown autofocus method")
@@ -378,9 +389,11 @@ def get_sample_name(sample: dict[str, Any]) -> str:
     """Return sample name."""
     return sample.get("name", "Unknown sample")
 
+
 def get_sample_species(sample: dict[str, Any]) -> str:
     """Return sample species."""
     return sample.get("species", "Unknown species")
+
 
 def get_sample_type(sample: dict[str, Any]) -> str:
     """Return sample type."""
@@ -389,9 +402,11 @@ def get_sample_type(sample: dict[str, Any]) -> str:
     sample_type = sample_type.replace("SampleType_", "")
     return sample_type
 
+
 def get_sample_organ(sample: dict[str, Any]) -> str:
     """Return sample organ."""
     return sample.get("organ", "Unknown organ")
+
 
 def get_sample_fixation_method(sample: dict[str, Any]) -> str:
     """Return sample fixation method."""
@@ -400,6 +415,7 @@ def get_sample_fixation_method(sample: dict[str, Any]) -> str:
 # --------------------------------------------------
 # Procedure block functions
 # --------------------------------------------------
+
 
 def add_numbers_to_run_cycles(blocks: dict[str, Any]) -> dict[str, Any]:
     """Add numbers to run cycles."""
@@ -413,10 +429,12 @@ def add_numbers_to_run_cycles(blocks: dict[str, Any]) -> dict[str, Any]:
         updated_blocks.append(block)
     return updated_blocks
 
+
 def get_run_cycle_number(block: dict[str, Any]) -> int:
     """Return the run cycle number."""
     logger.debug(f"Block keys: {block.keys()}")
     return block.get("runCycleNumber", "Unknown run cycle number")
+
 
 def get_block_type(block: dict[str, Any]) -> str:
     """Return the block type."""
@@ -426,9 +444,11 @@ def get_block_type(block: dict[str, Any]) -> str:
         block_type = block_type.replace("ProtocolBlockType_", "")
     return block_type
 
+
 def get_block_name(block: dict[str, Any]) -> str:
     """Return the block name."""
     return block.get("name", "Unknown block name")
+
 
 def get_block_magnification(block: dict[str, Any]) -> str:
     """Return the block magnification with 'Magnification_' prefix removed."""
@@ -437,6 +457,7 @@ def get_block_magnification(block: dict[str, Any]) -> str:
     if magnification is not None and magnification != "N/A" and magnification.startswith("Magnification_"):
         return magnification.replace("Magnification_", "")
     return magnification if magnification is not None else "N/A"
+
 
 def get_erase_bleaching_energy(block: dict[str, Any]) -> list[dict[str, Any]] | str:
     if block.get("blockType") != "ProtocolBlockType_Erase":
@@ -455,6 +476,7 @@ def get_erase_bleaching_energy(block: dict[str, Any]) -> list[dict[str, Any]] | 
             results.append({"Channel": label, "bleachingEnergy": energy})
 
     return results if results else "N/A"
+
 
 def get_erase_channel_info(block: dict[str, Any]) -> list[dict]:
     """
@@ -553,26 +575,26 @@ def build_bucket_lookup(data: dict) -> Dict[str, Dict[str, Any]]:
     bucket_to_reagent_id: Dict[str, str] = {}
     for proc in data.get("procedures", []):
         for link in proc.get("reagents", []):
-            bid  = link.get("bucketId")
-            rid  = link.get("reagentId", {}).get("itemId")
+            bid = link.get("bucketId")
+            rid = link.get("reagentId", {}).get("itemId")
             if bid and rid:
                 bucket_to_reagent_id[bid] = rid
 
     #  map reagent UUID ➜ metadata (comes from the global catalogue)
     catalogue: Dict[str, Dict[str, Any]] = {
         r["id"]: {
-            "antigen":      r.get("antigen",  "Unknown"),
-            "clone":        r.get("clone",    "N/A"),
+            "antigen": r.get("antigen", "Unknown"),
+            "clone": r.get("clone", "N/A"),
             "exposureTime": r.get("exposureTime", 0),
             "supportedFixationMethods": r.get("supportedFixationMethods", ""),
-            "Antibody":         r.get("antibody", ""),
-            "AntibodyType":     r.get("antibodyType", ""),
-            "HostSpecies":      r.get("hostSpecies", ""),
-            "Isotype":          r.get("isotype", ""),
-            "Manufacturer":     r.get("manufacturer", ""),
-            "Name":             r.get("name", ""),
-            "OrderNumber":      r.get("orderNumber", ""),
-            "Species":          r.get("species", ""),
+            "Antibody": r.get("antibody", ""),
+            "AntibodyType": r.get("antibodyType", ""),
+            "HostSpecies": r.get("hostSpecies", ""),
+            "Isotype": r.get("isotype", ""),
+            "Manufacturer": r.get("manufacturer", ""),
+            "Name": r.get("name", ""),
+            "OrderNumber": r.get("orderNumber", ""),
+            "Species": r.get("species", ""),
         }
         for r in data.get("reagents", [])
     }
@@ -585,7 +607,7 @@ def build_bucket_lookup(data: dict) -> Dict[str, Dict[str, Any]]:
 # ------------------------------------------------------------------ #
 def get_antigen_clone_by_bucket(bucket_id: str,
                                 bucket_lookup: Dict[str, Dict[str, str]]
-                               ) -> Optional[Tuple[str, str]]:
+                                ) -> Optional[Tuple[str, str]]:
     """
     Fast O(1) lookup using the pre-built dictionary.
     Returns (antigen, clone)  or  None if the bucket is unknown.
@@ -598,7 +620,7 @@ def get_antigen_clone_by_bucket(bucket_id: str,
 
 def get_antigen_clone_by_reagent_id(reagent_uuid: str,
                                     data: dict
-                                   ) -> Optional[Tuple[str, str]]:
+                                    ) -> Optional[Tuple[str, str]]:
     """
     Directly fetch antigen / clone when you already have the reagent UUID.
     Scans the global reagent catalogue only once per call.
@@ -608,6 +630,7 @@ def get_antigen_clone_by_reagent_id(reagent_uuid: str,
             return reagent.get("antigen", "Unknown"), reagent.get("clone", "N/A")
     return None
 
+
 def process_experiment(experiment: dict[str, Any]) -> dict[str, Any]:
     """
     Process experiment data and return formatted dictionary.
@@ -616,31 +639,34 @@ def process_experiment(experiment: dict[str, Any]) -> dict[str, Any]:
     ElapsedTime: Wall-clock time from start to end (includes pauses)
     """
     return format_dict_headers({
-        "ExperimentName":  get_experiment_name(experiment),
-        "StartTime":       get_start_time(experiment),
-        "EndTime":         get_end_time(experiment),
-        "RunningTime":     get_running_time(experiment),
-        "ElapsedTime":     get_elapsed_time(experiment),
-        "UsedDiskSpace":   get_used_disk_space(experiment),
+        "ExperimentName": get_experiment_name(experiment),
+        "StartTime": get_start_time(experiment),
+        "EndTime": get_end_time(experiment),
+        "RunningTime": get_running_time(experiment),
+        "ElapsedTime": get_elapsed_time(experiment),
+        "UsedDiskSpace": get_used_disk_space(experiment),
     })
+
 
 def process_rois(roi: dict[str, Any]) -> dict[str, Any]:
     return format_dict_headers({
-        "ROIName":    get_roi_name(roi),
-        "Shape":      get_roi_shape_type(roi),
-        "Height":     get_roi_shape_height(roi),
-        "Width":      get_roi_shape_width(roi),
-        "Autofocus":  get_autofocus_method(roi),
+        "ROIName": get_roi_name(roi),
+        "Shape": get_roi_shape_type(roi),
+        "Height": get_roi_shape_height(roi),
+        "Width": get_roi_shape_width(roi),
+        "Autofocus": get_autofocus_method(roi),
     })
+
 
 def process_sample(sample: dict[str, Any]) -> dict[str, Any]:
     return format_dict_headers({
-        "SampleName":   get_sample_name(sample),
-        "Species":      get_sample_species(sample),
-        "Type":         get_sample_type(sample),
-        "Organ":        get_sample_organ(sample),
-        "Fixation":     get_sample_fixation_method(sample),
+        "SampleName": get_sample_name(sample),
+        "Species": get_sample_species(sample),
+        "Type": get_sample_type(sample),
+        "Organ": get_sample_organ(sample),
+        "Fixation": get_sample_fixation_method(sample),
     })
+
 
 def propagate_magnification(blocks):
     last_mag = None
@@ -653,6 +679,7 @@ def propagate_magnification(blocks):
         new_block["magnification"] = last_mag
         out.append(new_block)
     return out
+
 
 def process_block(block: dict[str, Any],
                   bucket_lookup: dict[str, Any]) -> list[dict[str, Any]]:
@@ -794,14 +821,14 @@ def process_all_procedures(data: dict[str, Any], bucket_lookup: dict[str, Any]) 
 if __name__ == "__main__":
     json_path = get_input_path()
     logger.info(f"Loading JSON: {json_path}")
-    data          = load_json(json_path)
+    data = load_json(json_path)
     bucket_lookup = build_bucket_lookup(data)
 
     # ---------- gather rows ------------------------------------
-    exp_rows    = [process_experiment(e) for e in data["experiments"]]
-    rack_rows   = [{"RackName": get_rack_name(r)} for r in data["racks"]]
-    roi_rows    = [process_rois(r)       for r in data["rois"]]
-    sample_rows = [process_sample(s)     for s in data["samples"]]
+    exp_rows = [process_experiment(e) for e in data["experiments"]]
+    rack_rows = [{"RackName": get_rack_name(r)} for r in data["racks"]]
+    roi_rows = [process_rois(r) for r in data["rois"]]
+    sample_rows = [process_sample(s) for s in data["samples"]]
 
     # Process all procedures into a dictionary keyed by procedure name
     procedures_dict = process_all_procedures(data, bucket_lookup)
@@ -812,10 +839,10 @@ if __name__ == "__main__":
 
     import pandas as pd
     with pd.ExcelWriter(out_xlsx, engine="xlsxwriter") as xls:
-        pd.DataFrame(exp_rows   ).to_excel(xls, sheet_name="Experiment", index=False)
-        pd.DataFrame(rack_rows  ).to_excel(xls, sheet_name="Racks",      index=False)
-        pd.DataFrame(roi_rows   ).to_excel(xls, sheet_name="ROIs",       index=False)
-        pd.DataFrame(sample_rows).to_excel(xls, sheet_name="Samples",    index=False)
+        pd.DataFrame(exp_rows).to_excel(xls, sheet_name="Experiment", index=False)
+        pd.DataFrame(rack_rows).to_excel(xls, sheet_name="Racks", index=False)
+        pd.DataFrame(roi_rows).to_excel(xls, sheet_name="ROIs", index=False)
+        pd.DataFrame(sample_rows).to_excel(xls, sheet_name="Samples", index=False)
 
         # Write each procedure to its own sheet
         for proc_name, block_rows in procedures_dict.items():

--- a/src/macsima_parser.py
+++ b/src/macsima_parser.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any, Union, IO, Dict, Tuple, Optional
 import logging
 
+__version__ = "2.0.0"
+
 # Basic configuration
 logging.basicConfig(
     level=logging.INFO,
@@ -46,29 +48,29 @@ def add_blank_lines_between_run_cycles(block_rows: list[dict]) -> list[dict]:
     """
     if not block_rows:
         return block_rows
-    
+
     result = []
     prev_run_cycle = None
-    
+
     for row in block_rows:
         current_run_cycle = row.get(format_column_header("RunCycleNumber"), "")
-        
+
         # If this is a new run cycle (and not the first row), add a blank line
-        if (prev_run_cycle is not None and 
-            current_run_cycle != "" and 
+        if (prev_run_cycle is not None and
+            current_run_cycle != "" and
             current_run_cycle != prev_run_cycle and
             prev_run_cycle != ""):
-            
+
             # Create a blank row with the same keys but empty values
             blank_row = {key: "" for key in row.keys()}
             result.append(blank_row)
-        
+
         result.append(row)
-        
+
         # Update previous run cycle number if this row has one
         if current_run_cycle != "":
             prev_run_cycle = current_run_cycle
-    
+
     return result
 
 
@@ -108,7 +110,7 @@ def load_json(json_file: JsonFile) -> Any:
             return json.load(f)
     else:                                   # file handle already open
         return json.load(json_file)
-    
+
 
 # --------------------------------------------------
 # Experiment info helper functions
@@ -161,7 +163,7 @@ def sanitise_sheet_name(name: str, max_length: int = 31) -> str:
 
     return sanitised.strip() or "Procedure"
 
-def get_rack_name(rack: list[dict[str, Any]]) -> str:
+def get_rack_name(rack: dict[str, Any]) -> str:
     """Returns the rack name."""
     return rack.get("name", "Unknown rack")
 
@@ -282,7 +284,7 @@ def get_roi_shape_height(roi):
     try:
         shape_data_str = roi.get('shape', {}).get('Data', '{}')
         shape_data = json.loads(shape_data_str)
-        
+
         # Handle different shape data formats
         if isinstance(shape_data, dict):
             # Rectangle ROI - has Height and Width keys
@@ -306,14 +308,14 @@ def get_roi_shape_height(roi):
                         # Handle flat list format [x1, y1, x2, y2, ...]
                         # This is more complex, skip for now
                         pass
-                
+
                 if y_coords:
                     height = max(y_coords) - min(y_coords)
                 else:
                     height = "N/A"
         else:
             height = "N/A"
-            
+
     except (json.JSONDecodeError, TypeError, AttributeError) as e:
         height = "Unknown height"
         logger.warning(f"Error decoding JSON or accessing height: {e}")
@@ -324,7 +326,7 @@ def get_roi_shape_width(roi):
     try:
         shape_data_str = roi.get('shape', {}).get('Data', '{}')
         shape_data = json.loads(shape_data_str)
-        
+
         # Handle different shape data formats
         if isinstance(shape_data, dict):
             # Rectangle ROI - has Height and Width keys
@@ -348,14 +350,14 @@ def get_roi_shape_width(roi):
                         # Handle flat list format [x1, y1, x2, y2, ...]
                         # This is more complex, skip for now
                         pass
-                
+
                 if x_coords:
                     width = max(x_coords) - min(x_coords)
                 else:
                     width = "N/A"
         else:
             width = "N/A"
-            
+
     except (json.JSONDecodeError, TypeError, AttributeError) as e:
         width = "Unknown width"
         logger.warning(f"Error decoding JSON or accessing width: {e}")
@@ -439,19 +441,19 @@ def get_block_magnification(block: dict[str, Any]) -> str:
 def get_erase_bleaching_energy(block: dict[str, Any]) -> list[dict[str, Any]] | str:
     if block.get("blockType") != "ProtocolBlockType_Erase":
         return "N/A"
-    
+
     results = []
     channels = block.get("photos", {})
-    
+
     for channel in channels.values():
         fluor = channel.get("fluorochromeType")
         energy = channel.get("bleachingEnergy")
         enabled = channel.get("isEnabled", False)
-        
+
         if enabled and fluor and fluor != "FluorochromeType_None" and energy:
             label = fluor.split("_")[-1]  # FluorochromeType_APC → APC
             results.append({"Channel": label, "bleachingEnergy": energy})
-    
+
     return results if results else "N/A"
 
 def get_erase_channel_info(block: dict[str, Any]) -> list[dict]:
@@ -467,7 +469,7 @@ def get_erase_channel_info(block: dict[str, Any]) -> list[dict]:
     out = []
     for dc in block.get("photos", {}).values():
         if (
-            dc.get("isEnabled") 
+            dc.get("isEnabled")
             and dc.get("fluorochromeType") != "FluorochromeType_None"
         ):
             label = dc["fluorochromeType"].split("_")[-1]   # …_APC → APC
@@ -479,7 +481,7 @@ def get_erase_channel_info(block: dict[str, Any]) -> list[dict]:
             )
     return out
 
-  
+
 def get_run_cycle_channel_info(block: dict, bucket_lookup: dict) -> list[dict]:
     """
     Build a run-cycle channel summary for one ProtocolBlockType_RunCycle block.
@@ -654,25 +656,25 @@ def propagate_magnification(blocks):
 
 def process_block(block: dict[str, Any],
                   bucket_lookup: dict[str, Any]) -> list[dict[str, Any]]:
-    
+
     def create_ordered_row(**values):
         """Create a row with columns in the desired order."""
         # Define the desired column order
         column_order = [
             "RunCycleNumber", "BlockType", "Antigen", "Channel", "Magnification",
-            "Clone", "DilutionFactor", "IncubationTime", "ReagentExposure", 
+            "Clone", "DilutionFactor", "IncubationTime", "ReagentExposure",
             "Coefficient", "ActualExposure", "ErasingMethod", "BleachingEnergy", "BleachingTime",
             "ValidatedFor", "Antibody", "AntibodyType", "HostSpecies", "Isotype",
             "Manufacturer", "OrderNumber", "Species", "Name"
         ]
-        
+
         # Create ordered dictionary with empty defaults
         ordered_row = {}
         for col in column_order:
             ordered_row[col] = values.get(col, "")
-        
+
         return ordered_row
-    
+
     # Common values for all block types
     block_type = get_block_type(block)
     magnification = get_block_magnification(block)

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -572,18 +572,18 @@ def test_get_block_magnification_with_none():
         "name": "Test Block",
         "magnification": None
     }
-    
+
     # This should not raise an AttributeError
     extracted = mp.get_block_magnification(block_with_none_magnification)
     expected = "N/A"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
-    
+
     # Test case where magnification key doesn't exist
     block_without_magnification = {
         "blockType": "ProtocolBlockType_Scan",
         "name": "Test Block"
     }
-    
+
     extracted = mp.get_block_magnification(block_without_magnification)
     expected = "N/A"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
@@ -744,7 +744,7 @@ def test_reagent_details_extraction():
         info = channel.get("ChannelInfo", {})
         # These fields should always be present (blank if missing in data)
         for field in [
-            "Antigen", "Clone", "DilutionFactor", "IncubationTime", "ReagentExposureTime", 
+            "Antigen", "Clone", "DilutionFactor", "IncubationTime", "ReagentExposureTime",
             "ExposureCoefficient", "ActualExposureTime", "ErasingMethod", "BleachingEnergy", "BleachingTime", "ValidatedFor",
             "Antibody", "AntibodyType", "HostSpecies", "Isotype", "Manufacturer", "Name", "OrderNumber", "Species"
         ]:
@@ -895,22 +895,22 @@ def test_format_column_header():
     # Test basic camelCase
     assert mp.format_column_header("BleachingEnergy") == "Bleaching\nEnergy"
     assert mp.format_column_header("DilutionFactor") == "Dilution\nFactor"
-    
+
     # Test multi-word camelCase
     assert mp.format_column_header("ActualExposureTime") == "Actual\nExposure\nTime"
     assert mp.format_column_header("UsedDiskSpace") == "Used\nDisk\nSpace"
-    
+
     # Test acronym patterns
     assert mp.format_column_header("ROIName") == "ROI\nName"
     assert mp.format_column_header("XMLData") == "XML\nData"
-    
+
     # Test single words (no change)
     assert mp.format_column_header("Species") == "Species"
     assert mp.format_column_header("Height") == "Height"
-    
+
     # Test empty string
     assert mp.format_column_header("") == ""
-    
+
     # Test already formatted strings
     assert mp.format_column_header("Already\nFormatted") == "Already\nFormatted"
 
@@ -923,20 +923,20 @@ def test_format_dict_headers():
         "Species": "Human",
         "ROIName": "Test ROI"
     }
-    
+
     expected = {
         "Bleaching\nEnergy": 100,
         "Dilution\nFactor": 50,
         "Species": "Human",
         "ROI\nName": "Test ROI"
     }
-    
+
     result = mp.format_dict_headers(input_dict)
     assert result == expected
-    
+
     # Test empty dictionary
     assert mp.format_dict_headers({}) == {}
-    
+
     # Test dictionary with single key
     single_key_dict = {"TestKey": "value"}
     expected_single = {"Test\nKey": "value"}
@@ -954,31 +954,31 @@ def test_add_blank_lines_between_run_cycles():
         {"Block\nType": "RunCycle", "Run\nCycle\nNumber": "2", "Channel": "FITC"},
         {"Block\nType": "RunCycle", "Run\nCycle\nNumber": "3", "Channel": "DAPI"},
     ]
-    
+
     result = mp.add_blank_lines_between_run_cycles(input_rows)
-    
+
     # Should have 8 rows total (6 original + 2 blank lines)
     assert len(result) == 8
-    
+
     # Check that blank lines are inserted at the right positions
     assert result[0] == input_rows[0]  # Scan block
     assert result[1] == input_rows[1]  # RunCycle 1, DAPI
     assert result[2] == input_rows[2]  # RunCycle 1, FITC
-    
+
     # Blank line after run cycle 1
     assert result[3] == {"Block\nType": "", "Run\nCycle\nNumber": "", "Channel": ""}
-    
+
     assert result[4] == input_rows[3]  # RunCycle 2, DAPI
     assert result[5] == input_rows[4]  # RunCycle 2, FITC
-    
+
     # Blank line after run cycle 2
     assert result[6] == {"Block\nType": "", "Run\nCycle\nNumber": "", "Channel": ""}
-    
+
     assert result[7] == input_rows[5]  # RunCycle 3, DAPI
-    
+
     # Test empty list
     assert mp.add_blank_lines_between_run_cycles([]) == []
-    
+
     # Test single run cycle (no blank lines should be added)
     single_cycle = [
         {"Block\nType": "RunCycle", "Run\nCycle\nNumber": "1", "Channel": "DAPI"},
@@ -986,7 +986,7 @@ def test_add_blank_lines_between_run_cycles():
     ]
     result_single = mp.add_blank_lines_between_run_cycles(single_cycle)
     assert result_single == single_cycle  # No changes
-    
+
     # Test non-RunCycle blocks only
     non_run_cycle = [
         {"Block\nType": "Scan", "Run\nCycle\nNumber": "", "Channel": "DAPI"},
@@ -1000,25 +1000,25 @@ def test_get_erase_channel_info():
     """Test that erase channel info is extracted correctly."""
     # Test with erase block from dummy data
     erase_block = data['procedures'][0]['blocks'][3]  # This should be an erase block
-    
+
     extracted = mp.get_erase_channel_info(erase_block)
-    
+
     # Should return a list of channel info dictionaries
     assert isinstance(extracted, list)
     assert len(extracted) == 3  # FITC, PE, APC
-    
+
     # Check first channel
     assert extracted[0]["Channel"] == "FITC"
     assert extracted[0]["ChannelInfo"]["BleachingEnergy"] == 1980
-    
+
     # Check second channel
     assert extracted[1]["Channel"] == "PE"
     assert extracted[1]["ChannelInfo"]["BleachingEnergy"] == 840
-    
+
     # Check third channel
     assert extracted[2]["Channel"] == "APC"
     assert extracted[2]["ChannelInfo"]["BleachingEnergy"] == 780
-    
+
     # Test with non-erase block (should return empty list)
     scan_block = data['procedures'][0]['blocks'][0]  # This should be a scan block
     result_non_erase = mp.get_erase_channel_info(scan_block)
@@ -1028,10 +1028,10 @@ def test_get_erase_channel_info():
 def test_build_bucket_lookup():
     """Test that bucket lookup is built correctly."""
     bucket_lookup = mp.build_bucket_lookup(data)
-    
+
     # Should return a dictionary (even if empty for our test data)
     assert isinstance(bucket_lookup, dict)
-    
+
     # Test with minimal data structure that has proper reagent mappings
     test_data = {
         "procedures": [
@@ -1059,7 +1059,7 @@ def test_build_bucket_lookup():
                 "species": "human"
             },
             {
-                "id": "reagent2", 
+                "id": "reagent2",
                 "antigen": "CD4",
                 "clone": "Clone2",
                 "exposureTime": 120,
@@ -1075,13 +1075,13 @@ def test_build_bucket_lookup():
             }
         ]
     }
-    
+
     lookup = mp.build_bucket_lookup(test_data)
-    
+
     # Should have mappings for both buckets
     assert "bucket1" in lookup
     assert "bucket2" in lookup
-    
+
     # Check bucket1 mapping
     bucket1_info = lookup["bucket1"]
     assert bucket1_info["antigen"] == "CD3"
@@ -1089,7 +1089,7 @@ def test_build_bucket_lookup():
     assert bucket1_info["exposureTime"] == 100
     assert bucket1_info["Antibody"] == "CD3_antibody"
     assert bucket1_info["Manufacturer"] == "TestCorp"
-    
+
     # Check bucket2 mapping
     bucket2_info = lookup["bucket2"]
     assert bucket2_info["antigen"] == "CD4"
@@ -1102,22 +1102,22 @@ def test_process_experiment():
     """Test that experiment data is processed correctly with formatted headers."""
     experiment = data['experiments'][0]
     result = mp.process_experiment(experiment)
-    
+
     # Check that result is a dictionary
     assert isinstance(result, dict)
-    
+
     # Check that headers are formatted (have line breaks)
     expected_keys = [
         "Experiment\nName",
-        "Start\nTime", 
+        "Start\nTime",
         "End\nTime",
         "Running\nTime",
         "Used\nDisk\nSpace"
     ]
-    
+
     for key in expected_keys:
         assert key in result
-    
+
     # Check values
     assert result["Experiment\nName"] == "250128_liver_OCT_FCRB 1"
     assert result["Start\nTime"] == "2025-01-28T15:53:36Z"
@@ -1130,29 +1130,29 @@ def test_process_rois():
     """Test that ROI data is processed correctly with formatted headers."""
     roi = data['rois'][0]
     result = mp.process_rois(roi)
-    
+
     # Check that result is a dictionary
     assert isinstance(result, dict)
-    
+
     # Check that headers are formatted (have line breaks)
     expected_keys = [
         "ROI\nName",
         "Shape",
-        "Height", 
+        "Height",
         "Width",
         "Autofocus"
     ]
-    
+
     for key in expected_keys:
         assert key in result
-    
+
     # Check values
     assert result["ROI\nName"] == "C Overview"
     assert result["Shape"] == "Rectangle"
     assert result["Height"] == "10"
     assert result["Width"] == "19"
     assert result["Autofocus"] == "ImageBased"
-    
+
     # Test with second ROI
     roi2 = data['rois'][1]
     result2 = mp.process_rois(roi2)
@@ -1164,10 +1164,10 @@ def test_process_sample():
     """Test that sample data is processed correctly with formatted headers."""
     sample = data['samples'][0]
     result = mp.process_sample(sample)
-    
+
     # Check that result is a dictionary
     assert isinstance(result, dict)
-    
+
     # Check that headers are formatted (have line breaks)
     expected_keys = [
         "Sample\nName",
@@ -1176,10 +1176,10 @@ def test_process_sample():
         "Organ",
         "Fixation"
     ]
-    
+
     for key in expected_keys:
         assert key in result
-    
+
     # Check values
     assert result["Sample\nName"] == "250128_liver_OCT_FCRB"
     assert result["Species"] == "Human"
@@ -1191,15 +1191,15 @@ def test_process_sample():
 def test_process_block_column_order():
     """Test that block processing maintains the correct column order."""
     bucket_lookup = mp.build_bucket_lookup(data)
-    
+
     # Test with a RunCycle block
     run_cycle_block = data['procedures'][0]['blocks'][5]  # RunCycle block
     result = mp.process_block(run_cycle_block, bucket_lookup)
-    
+
     # Should return a list of dictionaries
     assert isinstance(result, list)
     assert len(result) > 0
-    
+
     # Check that columns are in the correct order
     expected_order = [
         "Run\nCycle\nNumber", "Block\nType", "Antigen", "Channel", "Magnification",
@@ -1208,14 +1208,14 @@ def test_process_block_column_order():
         "Validated\nFor", "Antibody", "Antibody\nType", "Host\nSpecies", "Isotype",
         "Manufacturer", "Order\nNumber", "Species", "Name"
     ]
-    
+
     actual_columns = list(result[0].keys())
     assert actual_columns == expected_order
-    
+
     # Test with a non-RunCycle block
     scan_block = data['procedures'][0]['blocks'][0]  # Scan block
     result_scan = mp.process_block(scan_block, bucket_lookup)
-    
+
     # Should have the same column order (with most columns empty)
     actual_columns_scan = list(result_scan[0].keys())
     assert actual_columns_scan == expected_order
@@ -1224,32 +1224,32 @@ def test_process_block_column_order():
 def test_bleaching_time_extraction():
     """Test that bleaching time is extracted correctly from reagents."""
     bucket_lookup = mp.build_bucket_lookup(data)
-    
+
     # Test with RunCycle block that has bleaching time data
     run_cycle_block = data['procedures'][0]['blocks'][5]  # RunCycle block
     extracted = mp.get_run_cycle_channel_info(run_cycle_block, bucket_lookup)
-    
+
     # Should return a list of channel info dictionaries
     assert isinstance(extracted, list)
     assert len(extracted) == 5  # DAPI, FITC, PE, APC, Vio780
-    
+
     # Check bleaching time values for each channel
     channel_bleaching_times = {
         "DAPI": 0,      # DetectionChannel_1
-        "FITC": 15,     # DetectionChannel_2  
+        "FITC": 15,     # DetectionChannel_2
         "PE": 20,       # DetectionChannel_3
         "APC": 25,      # DetectionChannel_4
         "Vio780": 0     # DetectionChannel_5
     }
-    
+
     for channel_data in extracted:
         channel_name = channel_data["Channel"]
         expected_bleaching_time = channel_bleaching_times[channel_name]
         actual_bleaching_time = channel_data["ChannelInfo"]["BleachingTime"]
-        
+
         assert actual_bleaching_time == expected_bleaching_time, \
             f"Channel {channel_name}: expected BleachingTime {expected_bleaching_time}, got {actual_bleaching_time}"
-    
+
     # Test that BleachingTime field exists in all channels
     for channel_data in extracted:
         assert "BleachingTime" in channel_data["ChannelInfo"], \
@@ -1270,24 +1270,24 @@ def test_polygon_roi_handling():
             "method": "AutofocusMethod_ImageBased"
         }
     }
-    
+
     # These functions should not crash when called with polygon ROI
     name = mp.get_roi_name(polygon_roi)
     assert name == "Polygon ROI"
-    
+
     shape_type = mp.get_roi_shape_type(polygon_roi)
     assert shape_type == "Polygon"
-    
+
     # These should handle polygon data gracefully (not crash)
     height = mp.get_roi_shape_height(polygon_roi)
     width = mp.get_roi_shape_width(polygon_roi)
-    
+
     # Should return some reasonable value (not crash)
     assert height is not None
     assert width is not None
     assert isinstance(height, str)
     assert isinstance(width, str)
-    
+
     autofocus = mp.get_autofocus_method(polygon_roi)
     assert autofocus == "ImageBased"
 
@@ -1298,21 +1298,21 @@ def test_polygon_roi_with_different_formats():
     polygon_roi_list = {
         "name": "Polygon List",
         "shape": {
-            "Type": "ShapeType_Polygon", 
+            "Type": "ShapeType_Polygon",
             "Data": '[100.0, 100.0, 200.0, 100.0, 150.0, 200.0]'  # Flat list format
         },
         "autoFocus": {"method": "AutofocusMethod_ConstantZ"}
     }
-    
+
     # Should not crash
     height = mp.get_roi_shape_height(polygon_roi_list)
     width = mp.get_roi_shape_width(polygon_roi_list)
-    
+
     assert height is not None
     assert width is not None
     assert isinstance(height, str)
     assert isinstance(width, str)
-    
+
     # Test polygon with object format
     polygon_roi_objects = {
         "name": "Polygon Objects",
@@ -1322,11 +1322,11 @@ def test_polygon_roi_with_different_formats():
         },
         "autoFocus": {"method": "AutofocusMethod_Laser"}
     }
-    
+
     # Should not crash
     height = mp.get_roi_shape_height(polygon_roi_objects)
     width = mp.get_roi_shape_width(polygon_roi_objects)
-    
+
     assert height is not None
     assert width is not None
 
@@ -1342,14 +1342,14 @@ def test_malformed_roi_data():
         },
         "autoFocus": {"method": "AutofocusMethod_ImageBased"}
     }
-    
+
     # Should not crash, should return error message
     height = mp.get_roi_shape_height(invalid_json_roi)
     width = mp.get_roi_shape_width(invalid_json_roi)
-    
+
     assert height == "Unknown height"
     assert width == "Unknown width"
-    
+
     # Test with missing Data field
     missing_data_roi = {
         "name": "Missing Data",
@@ -1359,12 +1359,12 @@ def test_malformed_roi_data():
         },
         "autoFocus": {"method": "AutofocusMethod_ImageBased"}
     }
-    
+
     # Should not crash - missing Data field defaults to empty dict, so Height/Width will be None -> "N/A"
     height = mp.get_roi_shape_height(missing_data_roi)
     width = mp.get_roi_shape_width(missing_data_roi)
-    
-    assert height == "N/A" 
+
+    assert height == "N/A"
     assert width == "N/A"
 
 
@@ -1375,19 +1375,19 @@ def test_malformed_roi_data():
 def test_sample_files_trigger_expected_errors():
     """Test that our test sample files trigger the expected errors"""
     import os
-    
+
     # Test empty JSON file - should trigger JSONDecodeError
     empty_file = "../data/test-samples/invalid_empty.json"
     if os.path.exists(empty_file):
         with pytest.raises(json.JSONDecodeError):
             mp.load_json(empty_file)
-    
+
     # Test plain text file - should trigger JSONDecodeError
     text_file = "../data/test-samples/definitely_not_json.json"
     if os.path.exists(text_file):
         with pytest.raises(json.JSONDecodeError):
             mp.load_json(text_file)
-    
+
     # Test syntax error file - should trigger JSONDecodeError
     syntax_file = "../data/test-samples/invalid_syntax_error.json"
     if os.path.exists(syntax_file):
@@ -1398,30 +1398,30 @@ def test_sample_files_trigger_expected_errors():
 def test_missing_key_fields_trigger_keyerror():
     """Test that files with missing required fields trigger KeyError"""
     import os
-    
+
     # Test file with no experiments field
     missing_key_file = "../data/test-samples/missing_key_fields.json"
     if os.path.exists(missing_key_file):
         data = mp.load_json(missing_key_file)  # Should load JSON successfully
-        
+
         # But processing experiments should fail
         with pytest.raises(KeyError):
             exp_rows = [mp.process_experiment(e) for e in data["experiments"]]
-    
+
     # Test file missing experiments field
     missing_exp_file = "../data/test-samples/missing_experiments.json"
     if os.path.exists(missing_exp_file):
         data = mp.load_json(missing_exp_file)  # Should load JSON successfully
-        
+
         # But accessing experiments should fail
         with pytest.raises(KeyError):
             exp_rows = [mp.process_experiment(e) for e in data["experiments"]]
-    
+
     # Test file missing procedures field
     missing_proc_file = "../data/test-samples/missing_procedures.json"
     if os.path.exists(missing_proc_file):
         data = mp.load_json(missing_proc_file)  # Should load JSON successfully
-        
+
         # But accessing procedures should fail
         with pytest.raises(KeyError):
             blocks = data["procedures"]
@@ -1430,18 +1430,18 @@ def test_missing_key_fields_trigger_keyerror():
 def test_valid_sample_files_process_successfully():
     """Test that valid sample files process without errors"""
     import os
-    
+
     # Test minimal valid file
     minimal_file = "../data/test-samples/valid_minimal_sample.json"
     if os.path.exists(minimal_file):
         data = mp.load_json(minimal_file)  # Should load successfully
         bucket_lookup = mp.build_bucket_lookup(data)  # Should build successfully
-        
+
         # Should process experiments without error
         exp_rows = [mp.process_experiment(e) for e in data["experiments"]]
         assert len(exp_rows) == 1
         assert exp_rows[0]["ExperimentName"] == "Test Experiment"
-        
+
         # Should process procedures without error
         for proc in data["procedures"]:
             blocks = mp.add_numbers_to_run_cycles(proc["blocks"])
@@ -1455,33 +1455,33 @@ def test_flask_error_message_function():
     """Test the user-friendly error message function"""
     import sys
     import os
-    
+
     # Add the parent directory to the path to import from app.py
     parent_dir = os.path.join(os.path.dirname(__file__), '..')
     if parent_dir not in sys.path:
         sys.path.insert(0, parent_dir)
-    
+
     try:
         from app import get_user_friendly_error_message
-        
+
         # Test JSON decode error
         json_error = json.JSONDecodeError("Expecting value", "test", 0)
         message = get_user_friendly_error_message(json_error, "test.json")
         assert "not valid json" in message.lower()
         assert "test.json" in message
-        
+
         # Test KeyError
         key_error = KeyError("experiments")
         message = get_user_friendly_error_message(key_error, "test.json")
         assert "missing the required 'experiments' field" in message.lower()
         assert "test.json" in message
-        
+
         # Test generic error
         generic_error = Exception("Something went wrong")
         message = get_user_friendly_error_message(generic_error, "test.json")
         assert "unexpected error occurred" in message.lower()
         assert "test.json" in message
-        
+
     except ImportError:
         # Skip this test if Flask dependencies are not available
         pytest.skip("Flask dependencies not available for testing")

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -328,6 +328,18 @@ def test_get_end_time():
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
 
+def test_get_end_time_blank_for_incomplete_experiment():
+    """A blank end time means the experiment has not completed yet."""
+    experiment = {"executionEndDateTime": ""}
+
+    assert mp.get_end_time(experiment) == "N/A (not completed)"
+
+
+def test_get_end_time_missing_for_incomplete_experiment():
+    """A missing end time means the experiment has not completed yet."""
+    assert mp.get_end_time({}) == "N/A (not completed)"
+
+
 def test_get_running_time():
     """Test that the running time is extracted correctly."""
     extracted = mp.get_running_time(data['experiments'][0])

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -291,17 +291,20 @@ data = dummy_data
 # Experiment tests
 # --------------------------------------------------
 
+
 def test_get_experiment_name():
     """Test that the experiment name is extracted correctly."""
     extracted = mp.get_experiment_name(data['experiments'][0])
     expected = "250128_liver_OCT_FCRB 1"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_procedure_name():
     """Test that the procedure name is extracted correctly."""
     extracted = mp.get_procedure_name(data['procedures'][0])
     expected = "Standard procedure"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_rack_name():
     """Test that the rack name extracted correctly."""
@@ -310,17 +313,20 @@ def test_get_rack_name():
     # TODO: make sure this works with multiple racks
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_start_time():
     """Test that the start time is extracted correctly."""
     extracted = mp.get_start_time(data['experiments'][0])
     expected = "2025-01-28T15:53:36Z"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_end_time():
     """Test that the end time is extracted correctly."""
     extracted = mp.get_end_time(data['experiments'][0])
     expected = "2025-01-29T06:43:08Z"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_running_time():
     """Test that the running time is extracted correctly."""
@@ -412,6 +418,7 @@ def test_get_roi_name():
     expected = "ROI 1"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_roi_shape_type():
     """Test that the ROI shape type is extracted correctly."""
     extracted = mp.get_roi_shape_type(data['rois'][0])
@@ -420,6 +427,7 @@ def test_get_roi_shape_type():
     extracted = mp.get_roi_shape_type(data['rois'][1])
     expected = "Rectangle"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_roi_shape_height():
     """Test that the ROI shape height is extracted correctly."""
@@ -430,6 +438,7 @@ def test_get_roi_shape_height():
     expected = "2.350855833425806"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_roi_shape_width():
     """Test that the ROI shape width is extracted correctly."""
     extracted = mp.get_roi_shape_width(data['rois'][0])
@@ -438,6 +447,7 @@ def test_get_roi_shape_width():
     extracted = mp.get_roi_shape_width(data['rois'][1])
     expected = "2.6345827695784165"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_autofocus_method():
     """Test that the autofocus method is extracted correctly."""
@@ -452,11 +462,13 @@ def test_get_autofocus_method():
 # Sample tests
 # --------------------------------------------------
 
+
 def test_get_sample_name():
     """Test that the sample name is extracted correctly."""
     extracted = mp.get_sample_name(data['samples'][0])
     expected = "250128_liver_OCT_FCRB"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_sample_species():
     """Test that the sample species is extracted correctly."""
@@ -464,17 +476,20 @@ def test_get_sample_species():
     expected = "Human"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_sample_type():
     """Test that the sample type is extracted correctly."""
     extracted = mp.get_sample_type(data['samples'][0])
     expected = "Tissue"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_sample_organ():
     """Test that the sample organ is extracted correctly."""
     extracted = mp.get_sample_organ(data['samples'][0])
     expected = "Liver"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_sample_fixation_method():
     """Test that the sample fixation method is extracted correctly."""
@@ -485,6 +500,7 @@ def test_get_sample_fixation_method():
 # --------------------------------------------------
 # Procedure block tests
 # --------------------------------------------------
+
 
 def test_get_run_cycle_number():
     """Test that the run cycle number is extracted correctly."""
@@ -499,6 +515,7 @@ def test_get_run_cycle_number():
     extracted = mp.get_run_cycle_number(blocks_with_run_cycle_numbers[7])
     expected = 3
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_block_type():
     """Test that the block type is extracted correctly."""
@@ -521,6 +538,7 @@ def test_get_block_type():
     expected = "RunCycle"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_block_name():
     """Test that the block name is extracted correctly."""
     extracted = mp.get_block_name(data['procedures'][0]['blocks'][0])
@@ -541,6 +559,7 @@ def test_get_block_name():
     extracted = mp.get_block_name(data['procedures'][0]['blocks'][5])
     expected = "Run Cycle"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_block_magnification():
     """Test that the block magnification is extracted correctly."""
@@ -588,17 +607,19 @@ def test_get_block_magnification_with_none():
     expected = "N/A"
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
 
+
 def test_get_erase_bleaching_energy():
     """Test that the bleaching energy per channel for erase block is extracted correctly."""
     extracted = mp.get_erase_bleaching_energy(data['procedures'][0]['blocks'][3])
-    expected = [{"Channel": "FITC", "bleachingEnergy": 1980}, { "Channel": "PE", "bleachingEnergy": 840,}, {"Channel": "APC", "bleachingEnergy": 780,}]
+    expected = [{"Channel": "FITC", "bleachingEnergy": 1980}, {"Channel": "PE", "bleachingEnergy": 840, }, {"Channel": "APC", "bleachingEnergy": 780, }]
     # TODO: make sure data types are defined
     assert extracted == expected, f"Expected {expected}, but got {extracted}"
+
 
 def test_get_run_cycle_channel_info():
     """Test that the run cycle channel info is extracted correctly."""
     bucket_lookup = mp.build_bucket_lookup(data)
-    block         = data['procedures'][0]['blocks'][5]
+    block = data['procedures'][0]['blocks'][5]
     extracted = mp.get_run_cycle_channel_info(
         block,
         bucket_lookup=bucket_lookup,
@@ -865,6 +886,8 @@ def test_propagate_magnification():
 # --------------------------------------------------
 # Pure‑function unit tests
 # --------------------------------------------------
+
+
 @pytest.mark.parametrize(
     "seconds, expected",
     [(0, (0, 0, 0)), (1, (0, 0, 1)), (61, (0, 1, 1)), (3661, (1, 1, 1))],
@@ -877,6 +900,7 @@ def test_load_json(sample_json_file):
     data = mp.load_json(sample_json_file)
     # Minimal sanity check
     assert data["experiments"][0]["name"] == "Exp‑1"
+
 
 def test_add_numbers_to_run_cycles():
     """Test for adding numbers to run cycles."""
@@ -1415,7 +1439,7 @@ def test_missing_key_fields_trigger_keyerror():
 
         # But accessing experiments should fail
         with pytest.raises(KeyError):
-            exp_rows = [mp.process_experiment(e) for e in data["experiments"]]
+            _ = [mp.process_experiment(e) for e in data["experiments"]]
 
     # Test file missing procedures field
     missing_proc_file = "../data/test-samples/missing_procedures.json"
@@ -1424,7 +1448,7 @@ def test_missing_key_fields_trigger_keyerror():
 
         # But accessing procedures should fail
         with pytest.raises(KeyError):
-            blocks = data["procedures"]
+            _ = data["procedures"]
 
 
 def test_valid_sample_files_process_successfully():

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -1523,7 +1523,8 @@ def test_sanitise_sheet_name_custom_max_length():
     name = "This is a test name"
     result = mp.sanitise_sheet_name(name, max_length=10)
     assert len(result) <= 10
-    assert result == "This is a "
+    # Trailing space is stripped by the function
+    assert result == "This is a"
 
 
 def test_process_all_procedures_single():

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -1485,3 +1485,193 @@ def test_flask_error_message_function():
     except ImportError:
         # Skip this test if Flask dependencies are not available
         pytest.skip("Flask dependencies not available for testing")
+
+
+# --------------------------------------------------
+# Multiple procedures tests (Issue #16)
+# --------------------------------------------------
+
+def test_sanitise_sheet_name_basic():
+    """Test that sanitise_sheet_name handles basic cases correctly."""
+    # Normal name
+    assert mp.sanitise_sheet_name("Standard procedure") == "Standard procedure"
+
+    # Name with invalid characters
+    assert mp.sanitise_sheet_name("Proc/with\\invalid:chars?") == "Proc_with_invalid_chars_"
+
+    # Name with square brackets and asterisk
+    assert mp.sanitise_sheet_name("Proc[1]*test") == "Proc_1__test"
+
+
+def test_sanitise_sheet_name_length():
+    """Test that sanitise_sheet_name truncates long names to 31 characters."""
+    long_name = "This is a very long procedure name that exceeds the Excel limit"
+    result = mp.sanitise_sheet_name(long_name)
+    assert len(result) <= 31
+    assert result == "This is a very long procedure n"
+
+
+def test_sanitise_sheet_name_empty():
+    """Test that sanitise_sheet_name handles empty and blank names."""
+    assert mp.sanitise_sheet_name("") == "Procedure"
+    assert mp.sanitise_sheet_name("   ") == "Procedure"
+    assert mp.sanitise_sheet_name(None) == "Procedure"
+
+
+def test_sanitise_sheet_name_custom_max_length():
+    """Test that sanitise_sheet_name respects custom max_length."""
+    name = "This is a test name"
+    result = mp.sanitise_sheet_name(name, max_length=10)
+    assert len(result) <= 10
+    assert result == "This is a "
+
+
+def test_process_all_procedures_single():
+    """Test process_all_procedures with a single procedure."""
+    bucket_lookup = mp.build_bucket_lookup(data)
+    result = mp.process_all_procedures(data, bucket_lookup)
+
+    # Should return a dictionary with one entry
+    assert isinstance(result, dict)
+    assert len(result) == 1
+
+    # Key should be the procedure name
+    assert "Standard procedure" in result
+
+    # Value should be a list of block rows
+    block_rows = result["Standard procedure"]
+    assert isinstance(block_rows, list)
+    assert len(block_rows) > 0
+
+
+def test_process_all_procedures_multiple():
+    """Test process_all_procedures with multiple procedures."""
+    # Create data with multiple procedures
+    multi_proc_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": [
+            {
+                "comment": "Procedure A",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_2x"},
+                ]
+            },
+            {
+                "comment": "Procedure B",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_20x"},
+                ]
+            },
+            {
+                "comment": "Procedure C",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_40x"},
+                ]
+            }
+        ]
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(multi_proc_data)
+    result = mp.process_all_procedures(multi_proc_data, bucket_lookup)
+
+    # Should return a dictionary with three entries
+    assert isinstance(result, dict)
+    assert len(result) == 3
+
+    # Keys should be the procedure names
+    assert "Procedure A" in result
+    assert "Procedure B" in result
+    assert "Procedure C" in result
+
+
+def test_process_all_procedures_duplicate_names():
+    """Test process_all_procedures handles duplicate procedure names."""
+    # Create data with duplicate procedure names
+    dup_proc_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": [
+            {
+                "comment": "Same Name",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_2x"},
+                ]
+            },
+            {
+                "comment": "Same Name",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_20x"},
+                ]
+            },
+            {
+                "comment": "Same Name",
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_40x"},
+                ]
+            }
+        ]
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(dup_proc_data)
+    result = mp.process_all_procedures(dup_proc_data, bucket_lookup)
+
+    # Should return a dictionary with three unique entries
+    assert isinstance(result, dict)
+    assert len(result) == 3
+
+    # Keys should be unique with numeric suffixes
+    assert "Same Name" in result
+    assert "Same Name (2)" in result
+    assert "Same Name (3)" in result
+
+
+def test_process_all_procedures_empty():
+    """Test process_all_procedures with no procedures."""
+    empty_proc_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": []
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(empty_proc_data)
+    result = mp.process_all_procedures(empty_proc_data, bucket_lookup)
+
+    # Should return an empty dictionary
+    assert isinstance(result, dict)
+    assert len(result) == 0
+
+
+def test_process_all_procedures_missing_comment():
+    """Test process_all_procedures handles procedures without comments."""
+    no_comment_data = {
+        "experiments": data["experiments"],
+        "racks": data["racks"],
+        "rois": data["rois"],
+        "samples": data["samples"],
+        "reagents": data["reagents"],
+        "procedures": [
+            {
+                "blocks": [
+                    {"blockType": "ProtocolBlockType_Scan", "magnification": "Magnification_2x"},
+                ]
+            }
+        ]
+    }
+
+    bucket_lookup = mp.build_bucket_lookup(no_comment_data)
+    result = mp.process_all_procedures(no_comment_data, bucket_lookup)
+
+    # Should return a dictionary with one entry using the default name
+    assert isinstance(result, dict)
+    assert len(result) == 1
+    assert "Unknown procedure" in result

--- a/src/test_macsima_parser.py
+++ b/src/test_macsima_parser.py
@@ -1430,7 +1430,7 @@ def test_missing_key_fields_trigger_keyerror():
 
         # But processing experiments should fail
         with pytest.raises(KeyError):
-            exp_rows = [mp.process_experiment(e) for e in data["experiments"]]
+            _ = [mp.process_experiment(e) for e in data["experiments"]]
 
     # Test file missing experiments field
     missing_exp_file = "../data/test-samples/missing_experiments.json"


### PR DESCRIPTION
## Summary
  - Added `__version__ = "2.0.0"` to 
  macsima_parser.py
  - Fixed type hint on `get_rack_name()` (was 
  `list[dict]`, now `dict`)
  - Removed unused imports in app.py
  - Fixed bare `except:` clause
  - Fixed all PEP8 formatting issues (E302, W293, 
  W291, E221, E241, etc.)
  - Added GitHub Actions CI workflow for tests and
   linting on PRs

  ## Test plan
  - [x] All 64 tests pass (1 skipped - Flask 
  integration test)
  - [x] Zero flake8 linting errors
  - [ ] CI workflow runs successfully on this PR