### PR TITLE
chore: add repository gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# macOS
+.DS_Store
+
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
+# Coverage output
+.coverage
+.coverage.*
+htmlcov/
+
+# Local assistant instructions and working notes
+.claude/settings.local.json
+AGENTS.md
+CLAUDE.md
+A.md
+scratchpad_*.md


### PR DESCRIPTION
## Summary
- ignore macOS metadata and Python/test artifacts
- ignore coverage output
- ignore explicitly local assistant settings and scratchpads

## Test plan
- `pytest src/test_macsima_parser.py -q` (67 passed)
- `git diff --check origin/main..HEAD`

Closes #23