### PR TITLE
feat: show release version and deployed build

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import logging
 
 # Import your existing parser
 from src.macsima_parser import (
+    __version__,
     load_json,
     build_bucket_lookup,
     process_experiment,
@@ -25,6 +26,15 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 ALLOWED_EXTENSIONS = {'json'}
+
+
+def get_build_info():
+    """Return public release metadata for the running application."""
+    commit = os.environ.get('RENDER_GIT_COMMIT', '').strip()
+    return {
+        'version': __version__,
+        'commit': commit[:7] if commit else 'local',
+    }
 
 
 def allowed_file(filename):
@@ -112,7 +122,13 @@ def process_json_to_excel(json_file_path):
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    return render_template('index.html', build=get_build_info())
+
+
+@app.route('/health')
+def health():
+    """Report safe release metadata for deployment checks."""
+    return jsonify(status='ok', **get_build_info())
 
 
 @app.route('/upload', methods=['POST'])

--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
     env: python
     buildCommand: pip install -r requirements.txt
     startCommand: python app.py
+    healthCheckPath: /health
     envVars:
       - key: FLASK_ENV
         value: production

--- a/src/macsima_parser.py
+++ b/src/macsima_parser.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Union, IO, Dict, Tuple, Optional
 import logging
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 # Basic configuration
 logging.basicConfig(

--- a/templates/index.html
+++ b/templates/index.html
@@ -171,6 +171,12 @@
             background: rgba(0, 102, 204, 0.2);
             text-decoration: none;
         }
+
+        .build-info {
+            margin-top: 24px;
+            color: #6c757d;
+            font-size: 12px;
+        }
         
         .processing {
             display: none;
@@ -266,6 +272,10 @@
                 Processing...
             </div>
         </form>
+
+        <footer class="build-info" aria-label="Application version">
+            MACSima Parser v{{ build.version }} · build {{ build.commit }}
+        </footer>
     </div>
 
     <script>

--- a/test_app_metadata.py
+++ b/test_app_metadata.py
@@ -1,0 +1,42 @@
+from app import app, get_build_info
+
+
+def test_get_build_info_uses_render_commit(monkeypatch):
+    monkeypatch.setenv("RENDER_GIT_COMMIT", "0123456789abcdef")
+
+    assert get_build_info() == {
+        "version": "2.0.1",
+        "commit": "0123456",
+    }
+
+
+def test_get_build_info_has_local_fallback(monkeypatch):
+    monkeypatch.delenv("RENDER_GIT_COMMIT", raising=False)
+
+    assert get_build_info()["commit"] == "local"
+
+
+def test_health_returns_release_metadata(monkeypatch):
+    monkeypatch.setenv("RENDER_GIT_COMMIT", "abcdef1234567890")
+
+    with app.test_client() as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "ok",
+        "version": "2.0.1",
+        "commit": "abcdef1",
+    }
+
+
+def test_index_displays_release_metadata(monkeypatch):
+    monkeypatch.setenv("RENDER_GIT_COMMIT", "abcdef1234567890")
+
+    with app.test_client() as client:
+        response = client.get("/")
+
+    page = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert "v2.0.1" in page
+    assert "build abcdef1" in page


### PR DESCRIPTION
## Summary
- bump the application version to 2.0.1
- read the deployed SHA from Render's `RENDER_GIT_COMMIT` runtime variable
- display version and short build SHA in the UI footer
- expose safe release metadata at `/health`
- configure Render to use `/health` for service checks

## Design
The semantic version remains human-readable while the commit identifies the exact deployed source. Local development uses `build local` instead of invoking Git at request time.

## Test plan
- `pytest test_app_metadata.py -q` (4 passed)
- `pytest src/test_macsima_parser.py -q` (67 passed)
- `pytest -q` (74 passed)
- `git diff --check`

Closes #24